### PR TITLE
Only send bounced email when a sender is specified in message-headers

### DIFF
--- a/app/models/ep_postmaster/mailgun_post.rb
+++ b/app/models/ep_postmaster/mailgun_post.rb
@@ -8,7 +8,7 @@ module EpPostmaster
       @message_id = params["message-id"]
       @x_mailgun_sid = params["X-Mailgun-Sid"]
       @code = params.fetch("code")
-      @message_headers = JSON.parse(params["message-headers"])
+      @message_headers = JSON.parse(params["message-headers"]) rescue {}
       @domain = params["domain"]
       @error = params["error"]
       @event = params["event"]
@@ -48,11 +48,11 @@ module EpPostmaster
     def find_sender
       reply_to = message_headers.select { |header| header[0] == "Reply-To" }.first
       from = message_headers.select { |header| header[0] == "From" }.first
-      (reply_to || from)[1]
+      Array(reply_to || from)[1]
     end
     
     def find_subject
-      message_headers.select { |header| header[0] == "Subject" }.first[1]
+      Array(message_headers.select { |header| header[0] == "Subject" }.first)[1]
     end
   
   end

--- a/test/integration/ep_postmaster/mailgun_hooks_test.rb
+++ b/test/integration/ep_postmaster/mailgun_hooks_test.rb
@@ -32,11 +32,19 @@ module EpPostmaster
         mock(@dummy_bounced_email_handler).handle_bounced_email!(anything, anything)
         post "/mailgun/bounced_email", bounced_email_post
       end
+      
+      context "When mailgun posts a bounced email without message-headers" do
+      
+        should "skip sending the failed delivery email but still call the handler" do
+          mock(@dummy_bounced_email_handler).handle_bounced_email!(anything, anything)
+          assert_no_difference "ActionMailer::Base.deliveries.size" do
+            post "/mailgun/bounced_email", bounced_email_post.except("message-headers")
+          end
+        end
+      
+      end
 
     end
-  
-    
-    
   
   private
   


### PR DESCRIPTION
I need some feedback on this. Only 2 params are really required to handle a bounced email. The original recipient (bad email address) and the sender.

This PR will still process the post from mailgun even if it can't determine the sender. It just won't send an email notification. It will still call the `handle_bounced_email!` if a class was passed in. This way, we can still mark emails as not working even if for some reason the sender couldn't be determined.
