### PR TITLE
Fixed exception that can occur when processing dropped emails

### DIFF
--- a/app/models/ep_postmaster/mailgun_post.rb
+++ b/app/models/ep_postmaster/mailgun_post.rb
@@ -7,7 +7,7 @@ module EpPostmaster
     def initialize(params)
       @message_id = params["message-id"]
       @x_mailgun_sid = params["X-Mailgun-Sid"]
-      @code = params.fetch("code")
+      @code = params["code"]
       @message_headers = JSON.parse(params["message-headers"]) rescue {}
       @domain = params["domain"]
       @error = params["error"]

--- a/test/integration/ep_postmaster/mailgun_hooks_test.rb
+++ b/test/integration/ep_postmaster/mailgun_hooks_test.rb
@@ -2,25 +2,35 @@ require "test_helper"
 
 module EpPostmaster
   class MailgunHooksTest < ActionDispatch::IntegrationTest
-  
-    should "email a notice to the sender and return a 200" do
-      post "/mailgun/bounced_email", bounced_email_post
-      assert_equal "Failed Delivery to doesntexist@test.test: Original email subject", ActionMailer::Base.deliveries.first.subject
-    end
-  
+    
     should "return a 401 if the signature fails authentication" do
       post "mailgun/bounced_email", bounced_email_post.merge({"signature" => "gibberish"})
       assert_response :unauthorized # 401
     end
     
-    should "raise an exception if the status code is not a bounce" do
-      assert_raises WrongEndpointError do
-        post "mailgun/bounced_email", bounced_email_post.merge({"code" => 250, "event" => "completed"})
+    context "When we receive notification of a bounced email" do
+      should "email a notice to the sender and return a 200" do
+        post "/mailgun/bounced_email", bounced_email_post
+        assert_equal "Failed Delivery to doesntexist@test.test: Original email subject", ActionMailer::Base.deliveries.first.subject
+      end
+    end
+    
+    context "When we receive notification of a dropped email" do
+      should "email a notice to the sender and return a 200" do
+        post "/mailgun/bounced_email", dropped_email_post
+        assert_equal "Failed Delivery to doesntexist@test.test: Original email subject", ActionMailer::Base.deliveries.first.subject
+      end
+    end
+    
+    context "When we receive a notification we don't recognize" do
+      should "raise an exception" do
+        assert_raises WrongEndpointError do
+          post "mailgun/bounced_email", bounced_email_post.merge({"code" => 250, "event" => "completed"})
+        end
       end
     end
     
     context "When passing a class to handle the bounced email, it" do
-      
       setup do
         @dummy_bounced_email_handler = Class.new { def self.handle_bounced_email!(*); end }
         EpPostmaster.configure { |config| config.bounced_email_handler = @dummy_bounced_email_handler }
@@ -32,22 +42,23 @@ module EpPostmaster
       end
       
       context "When mailgun posts a bounced email without message-headers" do
-      
         should "skip sending the failed delivery email but still call the handler" do
           mock(@dummy_bounced_email_handler).handle_bounced_email!(anything, anything)
           assert_no_difference "ActionMailer::Base.deliveries.size" do
             post "/mailgun/bounced_email", bounced_email_post.except("message-headers")
           end
         end
-      
       end
-
     end
   
   private
   
     def bounced_email_post
       mailgun_posts[:bounced_email]
+    end
+  
+    def dropped_email_post
+      mailgun_posts[:dropped_email]
     end
   
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,13 +17,22 @@ end
 
 # Load test data for posts from Mailgun
 class ActiveSupport::TestCase
-
   attr_accessor :mailgun_posts
   
   setup do
-    @mailgun_posts = {}.tap do |posts| 
-      posts[:bounced_email] = EpPostmaster::DummyParams.new(from: "automail@test.test", reply_to: "sender@test.test", to: "doesntexist@test.test", event: :bounced_email, mailgun_api_key: "key-abc123").to_params
-    end
+    @mailgun_posts = {
+      bounced_email: EpPostmaster::DummyParams.new(
+        from: "automail@test.test",
+        reply_to: "sender@test.test",
+        to: "doesntexist@test.test",
+        event: :bounced_email,
+        mailgun_api_key: "key-abc123").to_params,
+      dropped_email: EpPostmaster::DummyParams.new(
+        from: "automail@test.test",
+        reply_to: "sender@test.test",
+        to: "doesntexist@test.test",
+        event: :dropped_email,
+        mailgun_api_key: "key-abc123").to_params }
     
     EpPostmaster.configure do |config|
       config.mailgun_api_key = "key-abc123"


### PR DESCRIPTION
When Mailgun posts a dropped email to EP::Postmaster, it doesn't always include a code.

This commit refactors the tests and DummyParams to bring that scenario under test and then makes a one-line change to EpPostmaster::MailgunPost
