### PR TITLE
Recognized error codes that include decimal points

### DIFF
--- a/app/models/ep_postmaster/mailgun_post.rb
+++ b/app/models/ep_postmaster/mailgun_post.rb
@@ -38,7 +38,7 @@ module EpPostmaster
     end
     
     def bounced_email?
-      /^5\d{2}$/ =~ code
+      /^5[\.\d]+$/ =~ code
     end
     
     def dropped_email?


### PR DESCRIPTION
See [EpPostmaster::WrongEndpointError: Unexpected post from Mailgun (code: 5.1.1, event: bounced)](https://errbit.cphepdev.com/apps/218/problems/8936)
