### PR TITLE
Update for Rails 5.1

### DIFF
--- a/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
+++ b/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
@@ -2,7 +2,7 @@ module EpPostmaster
   class MailgunHooksController < ActionController::Base
     attr_accessor :mailgun_post
 
-    before_filter :authenticate_request!, except: :test
+    before_action :authenticate_request!, except: :test
 
     def bounced_email
       unless mailgun_post.bounced_email? || mailgun_post.dropped_email?


### PR DESCRIPTION
`before_filter` is removed in Rails 5.1