### PR TITLE
Ignore a failed bounce email notification

### DIFF
--- a/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
+++ b/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
@@ -12,8 +12,11 @@ module EpPostmaster
       # Try and get Mailgun to resend POST
       head :unprocessable_entity unless event_data?
 
-      deliver_bounced_email_notification
-      call_bounced_email_handler if mailgun_post.undeliverable_email?
+      # Can't send to noreply address
+      unless mailgun_post.bounced_notification?
+        deliver_bounced_email_notification
+        call_bounced_email_handler if mailgun_post.undeliverable_email?
+      end
       head :no_content
     end
 

--- a/app/models/ep_postmaster/mailgun_post.rb
+++ b/app/models/ep_postmaster/mailgun_post.rb
@@ -62,6 +62,10 @@ module EpPostmaster
       reason == "dropped"
     end
 
+    def bounced_notification?
+      sender.to_s.include?("noreply")
+    end
+
     def get_error_message(delivery_status)
       # We might get both fields, but only one should have text
       message = delivery_status["message"].to_s.strip

--- a/test/integration/ep_postmaster/mailgun_hooks_test.rb
+++ b/test/integration/ep_postmaster/mailgun_hooks_test.rb
@@ -22,6 +22,20 @@ module EpPostmaster
       end
     end
 
+    context "When we recieve a failure for sending a bounced email notification" do
+      setup do
+        @dummy_bounced_email_handler = Class.new { def self.handle_bounced_email!(*); end }
+        EpPostmaster.configure { |config| config.bounced_email_handler = @dummy_bounced_email_handler }
+      end
+
+      should "ignore the failure" do
+        mock(@dummy_bounced_email_handler).handle_bounced_email!.never
+        assert_no_difference "ActionMailer::Base.deliveries.size" do
+          post "/mailgun/bounced_email", params: mailgun_posts[:bounced_notification], as: :json
+        end
+      end
+    end
+
     context "When we receive a notification we don't recognize" do
       should "raise an exception" do
         assert_raises WrongEndpointError do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,11 @@ class ActiveSupport::TestCase
         reply_to: "sender@test.test",
         to: "doesntexist@test.test",
         event: :dropped_email,
+        mailgun_api_key: "key-abc123").to_params,
+      bounced_notification: EpPostmaster::DummyParams.new(
+        from: "noreply@someserver.relay.com",
+        to: "somesender@test.test",
+        event: :bounced_email,
         mailgun_api_key: "key-abc123").to_params }
 
     EpPostmaster.configure do |config|


### PR DESCRIPTION
See: https://sentry.io/organizations/cphep/issues/2336539140/?project=5666899

To be tested with Members/Unite.  Test will just verify that this doesn't break things, that a bounced email notification is received, since it is unlikely to fail.