### PR TITLE
Skipped forgery protection for mailgun bounced email controller

### DIFF
--- a/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
+++ b/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
@@ -2,6 +2,8 @@ module EpPostmaster
   class MailgunHooksController < ActionController::Base
     attr_accessor :mailgun_post
 
+    skip_forgery_protection if allow_forgery_protection
+
     before_action :authenticate_request!, except: :test
 
     def bounced_email


### PR DESCRIPTION
### Summary
We don't expect Mailgun to provide a valid CSRF token... 😑 