### PR TITLE
Don't panic

### DIFF
--- a/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
+++ b/app/controllers/ep_postmaster/mailgun_hooks_controller.rb
@@ -2,7 +2,9 @@ module EpPostmaster
   class MailgunHooksController < ActionController::Base
     attr_accessor :mailgun_post
 
-    skip_forgery_protection if allow_forgery_protection
+    # Don't raise an error if we're already not doing
+    # forgery protection
+    skip_forgery_protection raise: false
 
     before_action :authenticate_request!, except: :test
 


### PR DESCRIPTION
### Summary

Apparently `raise: false` is a thing you can do when doing a `skip_before_action` 🤷‍♂️

Tested locally with `email_relay` where I set code to preload in development. Crashed before. Good to go now.